### PR TITLE
Applied Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 Certain wavelengths of electromagnetic radiation correspond to frequencies that allow the electrons in certain atoms to transition to higher or lower energy levels; as these wavelengths are absorbed by the sample, the resulting spectrum can yield insight into the chemical composition of the sample. Read more about spectroscopy [here](https://en.wikipedia.org/wiki/Spectroscopy). 
 
 ### dash-daq
-[Dash DAQ](http://dash-daq.netlify.com/#about) is a data acquisition and control package built on top of Plotly's [Dash](https://plot.ly/products/dash/).
+[Dash DAQ](https://www.dashdaq.io/) is a data acquisition and control package built on top of Plotly's [Dash](https://plot.ly/products/dash/).
 
 ## Requirements
 It is advisable	to create a separate conda environment running Python 3 for the app and install all of the required packages there. To do so, run (any version of Python 3 will work):


### PR DESCRIPTION
Made the following 4 changes.

1 - Update old dead [DashDaq](http://dash-daq.netlify.com/#about) link to new [DashDaq](https://www.dashdaq.io/) link.

2 - Regardless of the order they are declared in the `@app.callback`, callbacks evaluate `input` variables before `state` variables. This was causing [update the plot callback](https://github.com/plotly/dash-ocean-optics/blob/b420c5d05fe1dfe40ac52d24edf6b9246f84ab1d/app.py#L459-L470) to  use wrong arguments, hence causing `power-button` to not work properly. Reordered the arrangement of arguments to address this issue. 

3 - Sending light intensity and enabling/disabling `light-intensity-knob` in the same [callback](https://github.com/plotly/dash-ocean-optics/blob/b420c5d05fe1dfe40ac52d24edf6b9246f84ab1d/app.py#L373-L380) was causing the following loop:

<img width="634" alt="callback visual" src="https://user-images.githubusercontent.com/20918264/61665483-198f9e00-aca3-11e9-9f49-59e18b78b372.png">

Separated this single [callback](https://github.com/plotly/dash-ocean-optics/blob/b420c5d05fe1dfe40ac52d24edf6b9246f84ab1d/app.py#L373-L380) into 2 callbacks to solve the issue. 1 callback for sending light intensity. 1 callback for  enabling/disabling `light-intensity-knob`.

4 - Set `max_intervals` to `300` in `dcc.Interval`. This is done to stop triggering the interval callbacks after 5 mins. Otherwise server has to handle callbacks for idle app.
